### PR TITLE
bug: array out of bounds crash when raycast is hitting hitbox of piec…

### DIFF
--- a/Assets/Scripts/InputController.cs
+++ b/Assets/Scripts/InputController.cs
@@ -18,7 +18,7 @@ public class InputController : MonoBehaviour {
             if (hit.collider != null) {
                 var pos = hit.collider.transform.position;
                 Pools.pool.CreateEntity()
-                    .AddInput((int)pos.x, (int)pos.y);
+                    .AddInput(Mathf.FloorToInt(pos.x), Mathf.FloorToInt(pos.y));
             }
         } 
     }

--- a/Assets/Sources/Features/RenderResource/AddViewSystem.cs
+++ b/Assets/Sources/Features/RenderResource/AddViewSystem.cs
@@ -26,8 +26,8 @@ public class AddViewSystem : IReactiveSystem {
                 e.AddView(gameObject);
 
                 if (e.hasPosition) {
-                    var pos = e.position;
-                    gameObject.transform.position = new Vector3(pos.x, pos.y + 1, 0f);
+					var pos = e.position;
+					gameObject.transform.position = new Vector3(pos.x, pos.y + 0.999f, 0f);
                 }
             }
         }


### PR DESCRIPTION
…e that falls from y=9.5 and above (9.5f-10.0f) fix: floor raycasted screen positions to int + setting fall position for +0.999f

While the position of the falling piece has the value y+1 and the board height in the example is 8, the position of the hitbox of a piece will have values from 9 to 10. (y+1) Which result in an out of bounds exception when a piece above the board is hit while it's falling (only really happens in burst mode, but easily reproducable).
